### PR TITLE
Publish website with GitHub Actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,38 +4,11 @@ on:
   push:
     branches:
       - main
+      - crnh/pages-publish
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Install uv
-        uses: astral-sh/setup-uv@v5
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version-file: ".python-version"
-
-      - name: Build website
-        run: uv run quarto render --output-dir _site
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: demo-website
-          path: _site/
-
-  deploy:
-    needs: build
-    runs-on: ubuntu-latest
-
-    permissions:
-      contents: write # to write to the gh-pages branch
 
     steps:
       - name: Checkout repository
@@ -52,7 +25,28 @@ jobs:
         with:
           python-version-file: ".python-version"
 
-      - name: Publish Quarto website
-        run: uv run quarto publish gh-pages --no-prompt --no-browser
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build website
+        run: uv run quarto render --output-dir _site
+
+      - name: Upload artifact
+        id: deployment
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    permissions:
+      pages: write # to deploy to Pages
+      id-token: write # to verify the deployment originates from an appropriate source
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-      - crnh/pages-publish
 
 jobs:
   build:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -16,6 +16,10 @@ website:
         text: Visisipy
       - href: https://mreye.nl
         text: About us
+    right:
+      - icon: github
+        href: https://github.com/MREYE-LUMC/demos
+        aria-label: GitHub
 
 format:
   html:


### PR DESCRIPTION
## Problem

- First tried to publish using the `deploy-pages` action, which failed due to an incorrectly formatted artifact
- The switched to `quarto publish`, which has two downsides:
  - `quarto publish` publishes through the `gh-pages` branch;
  - You need to specify an e-mail address and username for the commit to this branch.
 
## Solution

Use the `upload-pages-artifact` action, which builds an artifact suitable for deployment to GitHub pages.