### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Potential fix for [https://github.com/MREYE-LUMC/demos/security/code-scanning/2](https://github.com/MREYE-LUMC/demos/security/code-scanning/2)

To fix the problem, explicitly set a `permissions` block with minimal required privileges for the `build` job. Place the block under the `build:` job definition (after `runs-on: ubuntu-latest`). The minimal recommended starting point is `contents: read`, which allows the job to read repository contents but prohibits writing. Adding this block will restrict the GITHUB_TOKEN in this job and follow the principle of least privilege. No other changes, imports, or methods are needed elsewhere.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
