### PR TITLE
Remove camera correction term from PAROS demo

### DIFF
--- a/paros/index.qmd
+++ b/paros/index.qmd
@@ -235,13 +235,10 @@ with ui.card():
         lens_back_curvature, glasses_curvature = eye.adjust_lens_back(
             eye.geometry["SE"], update_model=True
         )
-        magnification, glasses_power, _ = calculate_magnification(eye, camera)
+        magnification, *_ = calculate_magnification(eye, camera)
 
         return ui.markdown(
-            f"| Parameter                             | Value                    |\n"
-            f"| ------------------------------------- | ------------------------ |\n"
-            f"| Magnification eye model               | {abs(magnification):.2f} |\n"
-            f"| Necessary correction at camera phakic | {glasses_power:.2f} |\n"
+            f"**Magnification:** {abs(magnification):.2f}"
         )
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -1201,7 +1201,7 @@ dependencies = [
 requires-dist = [
     { name = "lzstring", specifier = ">=1.0.4" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
-    { name = "quarto-cli", specifier = ">=1.7.33" },
+    { name = "quarto-cli", specifier = ">=1.8.25" },
     { name = "shinylive", specifier = ">=0.8.3" },
     { name = "visisipy", specifier = ">=0.1.0" },
 ]


### PR DESCRIPTION
Remove the 'Necessary correction at camera phakic' output because it is confusing and redundant (it is just the spherical equivalent of refraction, which is equal to the input value in most cases). See also https://github.com/MREYE-LUMC/PAROS/issues/8.