### PR TITLE
Automatically resize iframes when their content changes size

### DIFF
--- a/_includes/resize-iframe.html
+++ b/_includes/resize-iframe.html
@@ -1,0 +1,1 @@
+<script src="/_includes/resize-iframe.js" defer></script>

--- a/_includes/resize-iframe.js
+++ b/_includes/resize-iframe.js
@@ -1,0 +1,53 @@
+const isIframeLoaded = (selector) => {
+    // Check if the iframe exists and has a valid src attribute
+    const iframe = document.querySelector(selector);
+    return iframe && iframe.src;
+}
+
+const waitForIframeLoad = (selector) => {
+    return new Promise((resolve) => {
+        if (isIframeLoaded(selector)) {
+            return resolve(document.querySelector(selector));
+        }
+
+        const observer = new MutationObserver(() => {
+            if (isIframeLoaded(selector)) {
+                observer.disconnect();
+                resolve(document.querySelector(selector));
+            }
+        });
+
+        observer.observe(document.body, {
+            childList: true,
+            subtree: true,
+        });
+    });
+}
+
+const registerObserver = (iframe, offset) => {
+    var lastHeight = iframe.contentWindow.document.body.scrollHeight;
+
+    const iframeObserver = new MutationObserver(() => {
+        const newHeight = iframe.contentWindow.document.body.scrollHeight;
+
+        if (newHeight !== lastHeight) {
+            console.log(`Resizing iframe from ${lastHeight}px to ${newHeight}px`);
+            lastHeight = newHeight;
+            iframe.style.height = `${newHeight + offset}px`;
+        }
+    });
+
+    iframeObserver.observe(iframe.contentWindow.document.body, {
+        subtree: true,
+        childList: true,
+    });
+}
+
+waitForIframeLoad('iframe.app-frame').then((iframe) => {
+    console.log("Iframe loaded, starting resize observer");
+
+    iframe.addEventListener('load', () => {
+        iframe.style.height = `${iframe.contentWindow.document.body.scrollHeight + 30}px`; // Initial height adjustment
+        registerObserver(iframe, 30); // Initial offset to account for padding/margin
+    });
+});

--- a/paros/index.qmd
+++ b/paros/index.qmd
@@ -7,7 +7,7 @@ editable: true
 
 format:
   html:
-    include-after-body: ../_includes/mdr-modal.html
+    include-after-body: [../_includes/mdr-modal.html, ../_includes/resize-iframe.html]
 ---
 
 This integration demonstrates how PAROS can be used to calculate the central magnification of a fundus image. More information can be found at our [GitHub repository](https://github.com/MREYE-LUMC/PAROS).
@@ -29,10 +29,10 @@ If you do not have all required parameters, it is possible to estimate some para
 - The posterior lens curvature can be fitted from the spherical equivalent of refraction.
     To do this, click the **Fit posterior lens curvature** button.
 
-:::{.column-screen-inset}
+:::{.column-screen}
 ```{shinylive-python}
 #| standalone: true
-#| viewerHeight: 1000
+#| viewerHeight: 400
 ## file: app.py
 from shiny import reactive
 from shiny.express import input, render, ui

--- a/visisipy/index.qmd
+++ b/visisipy/index.qmd
@@ -7,7 +7,7 @@ editable: true
 
 format:
   html:
-    include-after-body: ../_includes/mdr-modal.html
+    include-after-body: [../_includes/mdr-modal.html, ../_includes/resize-iframe.html]
 ---
 
 This is a demonstration of [visisipy](https://visisipy.readthedocs.io), our Python library for visual optics simulations.
@@ -21,10 +21,10 @@ This is a demonstration of [visisipy](https://visisipy.readthedocs.io), our Pyth
 Loading may take a while due to the installation of visisipy's dependencies.
 :::
 
-:::{.column-screen-inset}
+:::{.column-screen}
 ```{shinylive-python}
 #| standalone: true
-#| viewerHeight: 1100
+#| viewerHeight: 400
 ## file: app.py
 import visisipy
 import faicons


### PR DESCRIPTION
The Shiny apps are embedded in the demo pages as iframes. The size (width and height) of the iframes is determined by the demo page and not by the iframe's content (i.e. the Shiny app size). As a result, if the app gets larger than the iframe, a scroll bar appears. This happens quite often and results in a large scrolling element that can cover the entire viewport, which degrades the user experience. 
The iframe is now automatically resized when its content size changes. This ensures the frame is always large enough to prevent scrolling. Furthermore, the frames are now initially created with a height of 400px, which is too small for the content, but ensures the loading spinner is visible when the demo is still loading.

A downside of the current implementation is that it causes 'jumps' when collapsing a section in the sidebar of the visisipy demo. This could be solved by only updating the iframe height when the content's height is larger than the current height. However, that may result in a large empty space below the demo if the content's height decreases again.